### PR TITLE
Added templates that utilize init container to config address-settings

### DIFF
--- a/templates/templates/activemq-artemis-basic-with-init.yaml
+++ b/templates/templates/activemq-artemis-basic-with-init.yaml
@@ -1,0 +1,330 @@
+apiVersion: v1
+kind: Template
+labels:
+  template: activemq-artemis-basic
+  xpaas: '1.0'
+message: A new messaging service has been created in your project. It will handle the protocol(s) "${AMQ_PROTOCOL}". The username/password for accessing the service is ${AMQ_USER}/${AMQ_PASSWORD}.
+metadata:
+  annotations:
+    description: Application template for ActiveMQ Artemis brokers. This template doesn't feature SSL support.
+    iconClass: icon-amq
+    openshift.io/display-name: ActiveMQ Artemis Broker 2.13 (Ephemeral, no SSL)
+    openshift.io/provider-display-name: Apache Artemis
+    tags: messaging,amq,xpaas
+    template.openshift.io/documentation-url: 'https://github.com/artemiscloud/activemq-artemis-broker-openshift-image'
+    template.openshift.io/long-description: >-
+      This template defines resources needed to develop a ActiveMQ Artemis Broker 2.13 based application, including a deployment configuration, using ephemeral (temporary) storage.
+    template.openshift.io/support-url: 'https://github.com/artemiscloud'
+    version: '1.0'
+  name: activemq-artemis-basic
+objects:
+- apiVersion: v1
+  kind: Secret
+  metadata:
+    annotations:
+      description: Credentials used in broker config. Default values are admin(AMQ_USER and AMQ_PASSWORD).
+    name: amq-credential-secret
+  type: Opaque
+  data:
+    ${AMQ_USER}: YWRtaW4=
+    ${AMQ_PASSWORD}: YWRtaW4=
+- apiVersion: v1
+  kind: Service
+  metadata:
+    annotations:
+      description: The broker's console and Jolokia port.
+    labels:
+      application: ${APPLICATION_NAME}
+    name: ${AMQ_NAME}-amq-jolokia
+  spec:
+    ports:
+    - port: 8161
+      targetPort: 8161
+    selector:
+      deploymentConfig: ${APPLICATION_NAME}-amq
+- apiVersion: v1
+  kind: Service
+  metadata:
+    annotations:
+      description: The broker's Jolokia JVM Agent port.
+    labels:
+      application: ${APPLICATION_NAME}
+    name: ${AMQ_NAME}-amq-jolokia-jvm-agent
+  spec:
+    ports:
+    - port: 8778
+      targetPort: 8778
+    selector:
+      deploymentConfig: ${APPLICATION_NAME}-amq
+- apiVersion: v1
+  kind: Service
+  metadata:
+    annotations:
+      description: The broker's AMQP port.
+    labels:
+      application: ${APPLICATION_NAME}
+    name: ${AMQ_NAME}-amq-amqp
+  spec:
+    ports:
+    - port: 5672
+      targetPort: 5672
+    selector:
+      deploymentConfig: ${APPLICATION_NAME}-amq
+- apiVersion: v1
+  kind: Service
+  metadata:
+    annotations:
+      description: The broker's MQTT port.
+    labels:
+      application: ${APPLICATION_NAME}
+    name: ${AMQ_NAME}-amq-mqtt
+  spec:
+    ports:
+    - port: 1883
+      targetPort: 1883
+    selector:
+      deploymentConfig: ${APPLICATION_NAME}-amq
+- apiVersion: v1
+  kind: Service
+  metadata:
+    annotations:
+      description: The broker's STOMP port.
+    labels:
+      application: ${APPLICATION_NAME}
+    name: ${AMQ_NAME}-amq-stomp
+  spec:
+    ports:
+    - port: 61613
+      targetPort: 61613
+    selector:
+      deploymentConfig: ${APPLICATION_NAME}-amq
+- apiVersion: v1
+  kind: Service
+  metadata:
+    annotations:
+      description: The broker's OpenWire port.
+      service.alpha.openshift.io/dependencies: '[{"name": "${AMQ_NAME}-amq-amqp",
+        "kind": "Service"},{"name": "${AMQ_NAME}-amq-mqtt", "kind": "Service"},{"name":
+        "${AMQ_NAME}-amq-stomp", "kind": "Service"}]'
+    labels:
+      application: ${APPLICATION_NAME}
+    name: ${AMQ_NAME}-amq-tcp
+  spec:
+    ports:
+    - port: 61616
+      targetPort: 61616
+    selector:
+      deploymentConfig: ${APPLICATION_NAME}-amq
+- apiVersion: v1
+  kind: DeploymentConfig
+  metadata:
+    labels:
+      application: ${APPLICATION_NAME}
+    name: ${APPLICATION_NAME}-amq
+  spec:
+    replicas: 1
+    selector:
+      deploymentConfig: ${APPLICATION_NAME}-amq
+    strategy:
+      rollingParams:
+        maxSurge: 0
+      type: Rolling
+    template:
+      metadata:
+        labels:
+          application: ${APPLICATION_NAME}
+          deploymentConfig: ${APPLICATION_NAME}-amq
+        name: ${APPLICATION_NAME}-amq
+      spec:
+        initContainers:
+        - env:
+          - name: BROKER_INIT_IMAGE
+            value: ${BROKER_INIT_IMAGE}
+          - name: ADDRESS_SETTINGS_CONFIG
+            value: ${ADDRESS_SETTINGS_CONFIG}
+          - name: TUNE_PATH
+            value: ${TUNE_PATH}
+          name: activemq-artemis-init
+          image: ${BROKER_INIT_IMAGE}
+          command: ["/bin/bash", "-c", "if [[ ! -z \"${ADDRESS_SETTINGS_CONFIG}\" ]]; then yacfg --profile artemis/2.15.0/default_with_user_address_settings.yaml.jinja2  --tune <(echo \"${ADDRESS_SETTINGS_CONFIG}\") --output \"${TUNE_PATH}\"; fi;"]
+          volumeMounts:
+          - mountPath: ${TUNE_PATH}
+            name: tool-dir
+        containers:
+        - env:
+          - name: AMQ_USER
+            valueFrom:
+              secretKeyRef:
+                name: ${AMQ_CREDENTIAL_SECRET}
+                key: ${AMQ_USER}
+          - name: AMQ_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: ${AMQ_CREDENTIAL_SECRET}
+                key: ${AMQ_PASSWORD}
+          - name: AMQ_ROLE
+            value: ${AMQ_ROLE}
+          - name: AMQ_NAME
+            value: ${AMQ_NAME}
+          - name: AMQ_TRANSPORTS
+            value: ${AMQ_PROTOCOL}
+          - name: AMQ_QUEUES
+            value: ${AMQ_QUEUES}
+          - name: AMQ_ADDRESSES
+            value: ${AMQ_ADDRESSES}
+          - name: AMQ_GLOBAL_MAX_SIZE
+            value: ${AMQ_GLOBAL_MAX_SIZE}
+          - name: AMQ_REQUIRE_LOGIN
+            value: ${AMQ_REQUIRE_LOGIN}
+          - name: AMQ_EXTRA_ARGS
+            value: ${AMQ_EXTRA_ARGS}
+          - name: AMQ_ANYCAST_PREFIX
+            value: ${AMQ_ANYCAST_PREFIX}
+          - name: AMQ_MULTICAST_PREFIX
+            value: ${AMQ_MULTICAST_PREFIX}
+          - name: AMQ_ENABLE_METRICS_PLUGIN
+            value: ${AMQ_ENABLE_METRICS_PLUGIN}
+          - name: AMQ_JOURNAL_TYPE
+            value: ${AMQ_JOURNAL_TYPE}
+          - name: APPLY_RULE
+            value: ${APPLY_RULE}
+          - name: TUNE_PATH
+            value: ${TUNE_PATH}
+          image: ${IMAGE}
+          imagePullPolicy: Always
+          readinessProbe:
+            exec:
+              command:
+              - "/bin/bash"
+              - "-c"
+              - "/opt/amq/bin/readinessProbe.sh"
+          name: ${APPLICATION_NAME}-amq
+          volumeMounts:
+          - mountPath: ${TUNE_PATH}
+            name: tool-dir
+          ports:
+          - containerPort: 8161
+            name: console-jolokia
+            protocol: TCP
+          - containerPort: 8778
+            name: jolokia
+            protocol: TCP
+          - containerPort: 5672
+            name: amqp
+            protocol: TCP
+          - containerPort: 1883
+            name: mqtt
+            protocol: TCP
+          - containerPort: 61613
+            name: stomp
+            protocol: TCP
+          - containerPort: 61616
+            name: artemis
+            protocol: TCP
+        terminationGracePeriodSeconds: 60
+        volumes:
+        - emptyDir: {}
+          name: tool-dir
+    triggers:
+    - type: ConfigChange
+- apiVersion: v1
+  kind: Route
+  metadata:
+    labels:
+      application: ${APPLICATION_NAME}
+    name: console
+  spec:
+    to:
+      kind: Service
+      name: ${AMQ_NAME}-amq-jolokia
+parameters:
+- description: The name for the application.
+  displayName: Application Name
+  name: APPLICATION_NAME
+  required: true
+  value: broker
+- description: 'Protocols to configure, separated by commas. Allowed values are: `openwire`, `amqp`, `stomp`, `mqtt` and `hornetq`.'
+  displayName: AMQ Protocols
+  name: AMQ_PROTOCOL
+  value: openwire,amqp,stomp,mqtt,hornetq
+- description: Queue names, separated by commas. These queues will be automatically created when the broker starts. If left empty, queues will be still created dynamically.
+  displayName: Queues
+  name: AMQ_QUEUES
+- description: Address names, separated by commas. These addresses will be automatically created when the broker starts. If left empty, addresses will be still created dynamically.
+  displayName: Addresses
+  name: AMQ_ADDRESSES
+- description: User name for standard broker user. It is required for connecting to the broker. If left empty, it will be generated. It serves as a key by which the real user name is retrieved from kubernetes secret object.
+  displayName: AMQ Username
+  from: user[a-zA-Z0-9]{3}
+  generate: expression
+  name: AMQ_USER
+- description: Password for standard broker user. It is required for connecting to the broker. If left empty, it will be generated. It serves as a key by which the real password is retrieved from kubernetes secret object.
+  displayName: AMQ Password
+  from: '[a-zA-Z0-9]{8}'
+  generate: expression
+  name: AMQ_PASSWORD
+- description: User role for standard broker user.
+  displayName: AMQ Role
+  name: AMQ_ROLE
+  value: admin
+- description: The name of the broker
+  displayName: AMQ Name
+  name: AMQ_NAME
+  value: broker
+- description: "Maximum amount of memory which message data may consume (Default: Undefined, half of the system's memory)."
+  displayName: AMQ Global Max Size
+  name: AMQ_GLOBAL_MAX_SIZE
+  value: 100 gb
+- description: "Determines whether or not the broker will allow anonymous access, or require login"
+  displayName: AMQ Require Login
+  name: AMQ_REQUIRE_LOGIN
+- description: Extra arguments for broker creation
+  name: AMQ_EXTRA_ARGS
+  required: false
+- description: Anycast prefix applied to the multiplexed protocol port 61616
+  displayName: AMQ Anycast Prefix
+  name: AMQ_ANYCAST_PREFIX
+  required: false
+- description: Multicast prefix applied to the multiplexed protocol port 61616
+  displayName: AMQ Multicast Prefix
+  name: AMQ_MULTICAST_PREFIX
+  required: false
+- description: Namespace in which the ImageStreams for Red Hat Middleware images are installed. These ImageStreams are normally installed in the openshift namespace. You should only need to modify this if you've installed the ImageStreams in a different namespace/project.
+  displayName: ImageStream Namespace
+  name: IMAGE_STREAM_NAMESPACE
+  required: true
+  value: openshift
+- description: Broker Image
+  displayName: Image
+  name: IMAGE
+  required: true
+  value: quay.io/artemiscloud/activemq-artemis-broker-kubernetes:0.2.0
+- description: Broker init image
+  name: BROKER_INIT_IMAGE
+  required: false
+  value: quay.io/artemiscloud/activemq-artemis-broker-init:0.2.1
+- description: address settings for broker in yaml format consumed by init container
+  name: ADDRESS_SETTINGS_CONFIG
+  required: false
+  value: ""
+- description: controls the way how the ADDRESS_SETTINGS_CONFIG is applied to existing settings. Possible values are merge_all, merge_replace and replace_all
+  name: APPLY_RULE
+  value: 'merge_all'
+- description: location where yacfg generates the configuration files.
+  name: TUNE_PATH
+  value: '/yacfg_etc'
+- description: Name of a secret containing credential data such as passwords and SSL related files
+  displayName: Secret Name
+  name: AMQ_CREDENTIAL_SECRET
+  required: true
+  value: amq-credential-secret
+- description: Whether to enable artemis metrics plugin
+  displayName: Enable Metrics Plugin
+  name: AMQ_ENABLE_METRICS_PLUGIN
+  value: 'false'
+  required: false
+- description: Journal type to use; aio or nio supported
+  displayName: AMQ Journal Type
+  name: AMQ_JOURNAL_TYPE
+  value: nio
+  required: false

--- a/templates/templates/activemq-artemis-persistence-clustered-ssl-with-init.yaml
+++ b/templates/templates/activemq-artemis-persistence-clustered-ssl-with-init.yaml
@@ -1,0 +1,629 @@
+apiVersion: v1
+kind: Template
+labels:
+  template: activemq-artemis-persistence-clustered-ssl
+  xpaas: '1.0'
+message: A new messaging service with SSL support has been created in your project. It will handle the protocol(s) "${AMQ_PROTOCOL}". The username/password for accessing the service is ${AMQ_USER}/${AMQ_PASSWORD}. Please be sure to create a secret named "${AMQ_SECRET}" containing the trust store and key store files ("${AMQ_TRUSTSTORE}" and "${AMQ_KEYSTORE}") used for serving secure content.
+metadata:
+  annotations:
+    description: Application template for ActiveMQ Artemis brokers. This template supports SSL and requires usage of OpenShift secrets.
+    iconClass: icon-amq
+    openshift.io/display-name: ActiveMQ Artemis Broker 2.13 (Persistence, clustered, with SSL)
+    openshift.io/provider-display-name: Apache Artemis
+    tags: messaging,amq,xpaas
+    template.openshift.io/documentation-url: 'https://github.com/artemiscloud/activemq-artemis-broker-openshift-image'
+    template.openshift.io/long-description: >-
+      This template defines resources needed to develop a ActiveMQ Artemis Broker 2.13 based application, including a statefulset configuration, using persistent storage and secure communication using SSL.
+    template.openshift.io/support-url: 'https://github.com/artemiscloud'    
+    version: '1.0'
+  name: activemq-artemis-persistence-clustered-ssl
+objects:
+- apiVersion: v1
+  kind: Secret
+  metadata:
+    annotations:
+      description: Credentials used in broker config. Default values are admin(AMQ_USER and AMQ_PASSWORD), clusteruser(AMQ_CLUSTER_USER), clusterpassword(AMQ_CLUSTER_PASSWORD), password(AMQ_TRUSTORE_PASSWORD and AMQ_KEYSTORE_PASSWORD)
+    name: amq-credential-secret
+  type: Opaque
+  data:
+    ${AMQ_USER}: YWRtaW4=
+    ${AMQ_PASSWORD}: YWRtaW4=
+    ${AMQ_CLUSTER_USER}: Y2x1c3RlcnVzZXI=
+    ${AMQ_CLUSTER_PASSWORD}: Y2x1c3RlcnBhc3N3b3Jk
+    ${AMQ_TRUSTSTORE_PASSWORD}: cGFzc3dvcmQ=
+    ${AMQ_KEYSTORE_PASSWORD}: cGFzc3dvcmQ=
+- apiVersion: v1
+  kind: ServiceAccount
+  metadata:
+    name: ${APPLICATION_NAME}-service-account
+    labels:
+      app: ${APPLICATION_NAME}
+- apiVersion: rbac.authorization.k8s.io/v1beta1
+  kind: Role
+  metadata:
+    name: ${APPLICATION_NAME}-role
+    labels:
+      app: ${APPLICATION_NAME}
+  rules:
+  - apiGroups:
+    - ""
+    resources:
+    - endpoints
+    verbs:
+    - create
+    - delete
+    - deletecollection
+    - get
+    - list
+    - patch
+    - update
+    - watch
+  - apiGroups:
+    - ""
+    resources:
+    - namespaces
+    verbs:
+    - get
+    - list
+- apiVersion: rbac.authorization.k8s.io/v1beta1
+  kind: RoleBinding
+  metadata:
+    name: ${APPLICATION_NAME}-role-binding
+    labels:
+      app: ${APPLICATION_NAME}
+  subjects:
+    - kind: ServiceAccount
+      name: ${APPLICATION_NAME}-service-account
+  roleRef:
+    kind: Role
+    name: ${APPLICATION_NAME}-role
+    apiGroup: rbac.authorization.k8s.io
+- apiVersion: v1
+  kind: Service
+  metadata:
+    annotations:
+      description: The broker's headless, non load balanced service
+    labels:
+      application: ${APPLICATION_NAME}
+      app: ${APPLICATION_NAME}
+    name: ${AMQ_NAME}-amq-headless
+  spec:
+    clusterIP: None
+    publishNotReadyAddresses: true
+    ports:
+    - port: 61616
+      name: all
+      protocol: TCP
+      targetPort: 61616
+    - port: 8161
+      name: console-jolokia
+      protocol: TCP
+      targetPort: 8161
+    - port: 8778
+      name: jolokia
+      protocol: TCP
+      targetPort: 8778
+    - port: 5672
+      name: amqp
+      protocol: TCP
+      targetPort: 5672
+    - port: 1883
+      name: mqtt
+      protocol: TCP
+      targetPort: 1883
+    - port: 61613
+      name: stomp
+      protocol: TCP
+      targetPort: 61613
+    - port: 61617
+      name: all-ssl
+      protocol: TCP
+      targetPort: 61617
+    - port: 5671
+      name: amqp-ssl
+      protocol: TCP
+      targetPort: 5671
+    - port: 8883
+      name: mqtt-ssl
+      protocol: TCP
+      targetPort: 8883
+    - port: 61612
+      name: stomp-ssl
+      protocol: TCP
+      targetPort: 61612
+    selector:
+      deploymentConfig: ${APPLICATION_NAME}-amq
+    type: ClusterIP
+- apiVersion: v1
+  kind: Service
+  metadata:
+    annotations:
+      description: The JGroups ping port for clustering.
+      service.alpha.kubernetes.io/tolerate-unready-endpoints: 'true'
+    labels:
+      application: ${APPLICATION_NAME}
+    name: ${APPLICATION_NAME}-${PING_SVC_NAME}
+  spec:
+    clusterIP: None  
+    ports:
+      - targetPort: 8888
+        port: 8888
+    selector:
+      deploymentConfig: ${APPLICATION_NAME}-amq      
+- apiVersion: apps/v1beta1
+  kind: StatefulSet
+  metadata:
+    labels:
+      application: ${APPLICATION_NAME}
+    name: ${APPLICATION_NAME}-amq
+    annotations:
+      alpha.image.policy.openshift.io/resolve-names: '*'
+      statefulsets.kubernetes.io/drainer-pod-template: |
+        {
+          "metadata": {
+            "labels": {
+              "app": "${APPLICATION_NAME}-amq-drainer"
+            }
+          },
+          "spec": {
+            "serviceAccount": "${APPLICATION_NAME}-service-account",
+            "serviceAccountName": "${APPLICATION_NAME}-service-account",
+            "terminationGracePeriodSeconds": 5,
+            "containers": [
+              {
+                "env": [
+                  {
+                    "name": "APPLICATION_NAME",
+                    "value": "${APPLICATION_NAME}"
+                  },
+                  {
+                    "name": "PING_SVC_NAME",
+                    "value": "${PING_SVC_NAME}"
+                  },
+                  {
+                    "name": "AMQ_EXTRA_ARGS",
+                    "value": "--no-autotune"
+                  },
+                  {
+                    "name": "AMQ_USER",
+                    "valueFrom": {
+                      "secretKeyRef": {
+                        "name": "${AMQ_CREDENTIAL_SECRET}",
+                        "key": "${AMQ_USER}"
+                      }
+                    }
+                  },
+                  {
+                    "name": "AMQ_PASSWORD",
+                    "valueFrom": {
+                      "secretKeyRef": {
+                        "name": "${AMQ_CREDENTIAL_SECRET}",
+                        "key": "${AMQ_PASSWORD}"
+                      }
+                    }
+                  },
+                  {
+                    "name": "AMQ_ROLE",
+                    "value": "${AMQ_ROLE}"
+                  },
+                  {
+                    "name": "AMQ_NAME",
+                    "value": "${AMQ_NAME}"
+                  },
+                  {
+                    "name": "AMQ_TRANSPORTS",
+                    "value": "${AMQ_PROTOCOL}"
+                  },
+                  {
+                    "name": "AMQ_QUEUES",
+                    "value": "${AMQ_QUEUES}"
+                  },
+                  {
+                    "name": "AMQ_ADDRESSES",
+                    "value": "${AMQ_ADDRESSES}"
+                  },
+                  {
+                    "name": "AMQ_GLOBAL_MAX_SIZE",
+                    "value": "${AMQ_GLOBAL_MAX_SIZE}"
+                  },
+                  {
+                    "name": "AMQ_ALLOW_ANONYMOUS",
+                    "value": "${AMQ_ALLOW_ANONYMOUS}"
+                  },
+                  {
+                    "name": "AMQ_DATA_DIR",
+                    "value": "${AMQ_DATA_DIR}"
+                  },
+                  {
+                    "name": "AMQ_DATA_DIR_LOGGING",
+                    "value": "true"
+                  },
+                  {
+                    "name": "AMQ_CLUSTERED",
+                    "value": "${AMQ_CLUSTERED}"
+                  },
+                  {
+                    "name": "AMQ_REPLICAS",
+                    "value": "${AMQ_REPLICAS}"
+                  },
+                  {
+                    "name": "AMQ_CLUSTER_USER",
+                    "valueFrom": {
+                      "secretKeyRef": {
+                        "name": "${AMQ_CREDENTIAL_SECRET}",
+                        "key": "${AMQ_CLUSTER_USER}"
+                      }
+                    }
+                  },
+                  {
+                    "name": "AMQ_CLUSTER_PASSWORD",
+                    "valueFrom": {
+                      "secretKeyRef": {
+                        "name": "${AMQ_CREDENTIAL_SECRET}",
+                        "key": "${AMQ_CLUSTER_PASSWORD}"
+                      }
+                    }
+                  },
+                  {
+                    "name": "POD_NAMESPACE",
+                    "valueFrom": {
+                      "fieldRef": {
+                        "fieldPath": "metadata.namespace"
+                      }
+                    }
+                  },
+                  {
+                    "name": "OPENSHIFT_DNS_PING_SERVICE_PORT",
+                    "value": "8888"
+                  }
+                ],
+                "image": "${IMAGE}",
+                "name": "${APPLICATION_NAME}-amq",
+
+                "command": ["/bin/sh", "-c", "echo \"Starting the drainer\" ; /opt/amq/bin/drain.sh; echo \"Drain completed! Exit code $?\""],
+                "volumeMounts": [
+                  {
+                    "name": "${APPLICATION_NAME}-amq-pvol",
+                    "mountPath": "${AMQ_DATA_DIR}"
+                  }
+                ]
+              }
+            ]
+          }
+        }
+  spec:
+    podManagementPolicy: OrderedReady
+    replicas: ${AMQ_REPLICAS}
+    selector:
+      matchLabels:
+        app: ${APPLICATION_NAME}-amq
+    strategy:
+      rollingParams:
+        maxSurge: 0
+      type: Rolling
+    serviceName: ${AMQ_NAME}-amq-headless
+    template:
+      metadata:
+        labels:
+          application: ${APPLICATION_NAME}
+          deploymentConfig: ${APPLICATION_NAME}-amq
+          app: ${APPLICATION_NAME}-amq
+        name: ${APPLICATION_NAME}-amq
+      spec:
+        initContainers:
+        - env:
+          - name: BROKER_INIT_IMAGE
+            value: ${BROKER_INIT_IMAGE}
+          - name: ADDRESS_SETTINGS_CONFIG
+            value: ${ADDRESS_SETTINGS_CONFIG}
+          - name: TUNE_PATH
+            value: ${TUNE_PATH}
+          name: activemq-artemis-init
+          image: ${BROKER_INIT_IMAGE}
+          command: ["/bin/bash", "-c", "if [[ ! -z \"${ADDRESS_SETTINGS_CONFIG}\" ]]; then yacfg --profile artemis/2.15.0/default_with_user_address_settings.yaml.jinja2  --tune <(echo \"${ADDRESS_SETTINGS_CONFIG}\") --output \"${TUNE_PATH}\"; fi;"]
+          volumeMounts:
+          - mountPath: ${TUNE_PATH}
+            name: tool-dir
+        containers:
+        - env:
+          - name: APPLICATION_NAME
+            value: ${APPLICATION_NAME}
+          - name: PING_SVC_NAME
+            value: ${PING_SVC_NAME}
+          - name: AMQ_USER
+            valueFrom:
+              secretKeyRef:
+                name: ${AMQ_CREDENTIAL_SECRET}
+                key: ${AMQ_USER}
+          - name: AMQ_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: ${AMQ_CREDENTIAL_SECRET}
+                key: ${AMQ_PASSWORD}
+          - name: AMQ_ROLE
+            value: ${AMQ_ROLE}
+          - name: AMQ_NAME
+            value: ${AMQ_NAME}
+          - name: AMQ_TRANSPORTS
+            value: ${AMQ_PROTOCOL}
+          - name: AMQ_QUEUES
+            value: ${AMQ_QUEUES}
+          - name: AMQ_ADDRESSES
+            value: ${AMQ_ADDRESSES}
+          - name: AMQ_KEYSTORE_TRUSTSTORE_DIR
+            value: /etc/amq-secret-volume
+          - name: AMQ_TRUSTSTORE
+            value: ${AMQ_TRUSTSTORE}
+          - name: AMQ_TRUSTSTORE_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: ${AMQ_CREDENTIAL_SECRET}
+                key: ${AMQ_TRUSTSTORE_PASSWORD}
+          - name: AMQ_KEYSTORE
+            value: ${AMQ_KEYSTORE}
+          - name: AMQ_KEYSTORE_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: ${AMQ_CREDENTIAL_SECRET}
+                key: ${AMQ_KEYSTORE_PASSWORD}
+          - name: AMQ_SSL_PROVIDER
+            value: ${AMQ_SSL_PROVIDER}
+          - name: AMQ_GLOBAL_MAX_SIZE
+            value: ${AMQ_GLOBAL_MAX_SIZE}
+          - name: AMQ_REQUIRE_LOGIN
+            value: ${AMQ_REQUIRE_LOGIN}
+          - name: AMQ_DATA_DIR
+            value: ${AMQ_DATA_DIR}
+          - name: AMQ_DATA_DIR_LOGGING
+            value: ${AMQ_DATA_DIR_LOGGING}
+          - name: AMQ_CLUSTERED
+            value: ${AMQ_CLUSTERED}
+          - name: AMQ_REPLICAS
+            value: ${AMQ_REPLICAS}
+          - name: AMQ_CLUSTER_USER
+            valueFrom:
+              secretKeyRef:
+                name: ${AMQ_CREDENTIAL_SECRET}
+                key: ${AMQ_CLUSTER_USER}
+          - name: AMQ_CLUSTER_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: ${AMQ_CREDENTIAL_SECRET}
+                key: ${AMQ_CLUSTER_PASSWORD}
+          - name: AMQ_EXTRA_ARGS
+            value: ${AMQ_EXTRA_ARGS}
+          - name: AMQ_ANYCAST_PREFIX
+            value: ${AMQ_ANYCAST_PREFIX}
+          - name: AMQ_MULTICAST_PREFIX
+            value: ${AMQ_MULTICAST_PREFIX}
+          - name: POD_NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
+          - name: AMQ_ENABLE_METRICS_PLUGIN
+            value: ${AMQ_ENABLE_METRICS_PLUGIN}
+          - name: AMQ_JOURNAL_TYPE
+            value: ${AMQ_JOURNAL_TYPE}
+          - name: APPLY_RULE
+            value: ${APPLY_RULE}
+          - name: TUNE_PATH
+            value: ${TUNE_PATH}
+          readinessProbe:
+            exec:
+              command:
+              - "/bin/bash"
+              - "-c"
+              - "/opt/amq/bin/readinessProbe.sh"
+          image: ${IMAGE}
+          name: ${APPLICATION_NAME}-amq
+          volumeMounts:
+          - mountPath: ${TUNE_PATH}
+            name: tool-dir
+          ports:
+          - containerPort: 8161
+            name: console-jolokia
+            protocol: TCP
+          - containerPort: 8778
+            name: jolokia
+            protocol: TCP
+          - containerPort: 5672
+            name: amqp
+            protocol: TCP
+          - containerPort: 5671
+            name: amqp-ssl
+            protocol: TCP
+          - containerPort: 1883
+            name: mqtt
+            protocol: TCP
+          - containerPort: 8883
+            name: mqtt-ssl
+            protocol: TCP
+          - containerPort: 61613
+            name: stomp
+            protocol: TCP
+          - containerPort: 61612
+            name: stomp-ssl
+            protocol: TCP
+          - containerPort: 61616
+            name: all
+            protocol: TCP
+          - containerPort: 61617
+            name: all-ssl
+            protocol: TCP
+          volumeMounts:
+          - name: ${APPLICATION_NAME}-amq-pvol
+            mountPath: ${AMQ_DATA_DIR}
+          - mountPath: /etc/amq-secret-volume
+            name: broker-secret-volume
+            readOnly: true
+          - mountPath: ${TUNE_PATH}
+            name: tool-dir
+        terminationGracePeriodSeconds: 60
+        volumes:
+        - name: broker-secret-volume
+          secret:
+            secretName: ${AMQ_SECRET}
+        - emptyDir: {}
+          name: tool-dir
+    volumeClaimTemplates:
+    - apiVersion: v1
+      kind: PersistentVolumeClaim
+      metadata:
+        name: ${APPLICATION_NAME}-amq-pvol
+      spec:
+        accessModes:
+          - "ReadWriteOnce"
+        resources:
+          requests:
+            storage: ${VOLUME_CAPACITY}
+    triggers:
+    - type: ConfigChange
+parameters:
+- description: The name for the application.
+  displayName: Application Name
+  name: APPLICATION_NAME
+  required: true
+  value: broker
+- description: The name for JGroups DNS_PING service.
+  displayName: DNS Ping Service Name
+  name: PING_SVC_NAME
+  required: true
+  value: ping
+- description: 'Protocols to configure, separated by commas. Allowed values are: `openwire`, `amqp`, `stomp`, `mqtt` and `hornetq`.'
+  displayName: AMQ Protocols
+  name: AMQ_PROTOCOL
+  value: openwire,amqp,stomp,mqtt,hornetq
+- description: Queue names, separated by commas. These queues will be automatically created when the broker starts. If left empty, queues will be still created dynamically.
+  displayName: Queues
+  name: AMQ_QUEUES
+- description: Address names, separated by commas. These addresses will be automatically created when the broker starts. If left empty, addresses will be still created dynamically.
+  displayName: Addresses
+  name: AMQ_ADDRESSES
+- description: Size of the volume used by AMQ for persisting messages.
+  displayName: AMQ Volume Size
+  name: VOLUME_CAPACITY
+  value: 1Gi
+  required: true
+- description: User name for standard broker user. It is required for connecting to the broker. If left empty, it will be generated.  It serves as a key by which the real user name is retrieved from kubernetes secret object.
+  displayName: AMQ Username
+  from: user[a-zA-Z0-9]{3}
+  generate: expression
+  name: AMQ_USER
+- description: Password for standard broker user. It is required for connecting to the broker. If left empty, it will be generated. It serves as a key by which the real password is retrieved from kubernetes secret object.
+  displayName: AMQ Password
+  from: '[a-zA-Z0-9]{8}'
+  generate: expression
+  name: AMQ_PASSWORD
+- description: User role for standard broker user.
+  displayName: AMQ Role
+  name: AMQ_ROLE
+  value: admin
+- description: The name of the broker
+  displayName: AMQ Name
+  name: AMQ_NAME
+  value: broker
+- description: Clustered
+  displayName: clustered
+  name: AMQ_CLUSTERED
+  value: 'true'
+- description: Number of broker replicas for a cluster
+  displayName: Number of Replicas
+  name: AMQ_REPLICAS
+  value: '0'
+- description: Clustered user It serves as a key by which the real cluster user name is retrieved from kubernetes secret object.
+  displayName: cluster user
+  from: user[a-zA-Z0-9]{3}
+  generate: expression  
+  name: AMQ_CLUSTER_USER
+- description: Clustered password. It serves as a key by which the real cluster password is retrieved from kubernetes secret object.
+  displayName: cluster password
+  from: '[a-zA-Z0-9]{8}'
+  generate: expression  
+  name: AMQ_CLUSTER_PASSWORD
+- description: "Maximum amount of memory which message data may consume (Default: Undefined, half of the system's memory)."
+  displayName: AMQ Global Max Size
+  name: AMQ_GLOBAL_MAX_SIZE
+  value: 100 gb
+- description: "Determines whether or not the broker will allow anonymous access, or require login"
+  displayName: AMQ Require Login
+  name: AMQ_REQUIRE_LOGIN
+- description: Name of a secret containing SSL related files
+  displayName: Secret Name
+  name: AMQ_SECRET
+  required: true
+  value: amq-app-secret
+- description: Name of a secret containing credential data such as usernames and passwords
+  displayName: Secret Name
+  name: AMQ_CREDENTIAL_SECRET
+  required: true
+  value: amq-credential-secret
+- description: SSL trust store filename
+  displayName: Trust Store Filename
+  name: AMQ_TRUSTSTORE
+  required: true
+  value: broker.ts
+- description: SSL trust store password
+  displayName: Trust Store Password
+  name: AMQ_TRUSTSTORE_PASSWORD
+  required: true
+- description: SSL key store filename
+  displayName: AMQ Keystore Filename
+  name: AMQ_KEYSTORE
+  required: true
+  value: broker.ks
+- description: Password for accessing SSL keystore
+  displayName: AMQ Keystore Password
+  name: AMQ_KEYSTORE_PASSWORD
+  required: true
+- description: SSL provider (JDK or OPENSSL) used in netty ssl acceptor
+  displayName: AMQ SSL Provider
+  name: AMQ_SSL_PROVIDER
+  required: false
+- description: The directory to use for data storage
+  displayName: AMQ Data Directory
+  name: AMQ_DATA_DIR
+  value: /opt/amq/data
+- description: Use the AMQ Data Directory for logging
+  displayName: AMQ Data Directory for logging
+  name: AMQ_DATA_DIR_LOGGING
+  value: 'true'
+- description: Extra arguments for broker creation
+  name: AMQ_EXTRA_ARGS
+  required: false
+- description: Anycast prefix applied to the multiplexed protocol ports 61616 and 61617
+  displayName: AMQ Anycast Prefix
+  name: AMQ_ANYCAST_PREFIX
+  required: false
+- description: Multicast prefix applied to the multiplexed protocol ports 61616 and 61617
+  displayName: AMQ Multicast Prefix
+  name: AMQ_MULTICAST_PREFIX
+  required: false
+- description: Broker Image
+  displayName: Image
+  name: IMAGE
+  required: true
+  value: quay.io/artemiscloud/activemq-artemis-broker-kubernetes:0.2.0
+- description: Broker init image
+  name: BROKER_INIT_IMAGE
+  required: false
+  value: quay.io/artemiscloud/activemq-artemis-broker-init:0.2.1
+- description: address settings for broker in yaml format consumed by init container
+  name: ADDRESS_SETTINGS_CONFIG
+  required: false
+  value: ""
+- description: controls the way how the ADDRESS_SETTINGS_CONFIG is applied to existing settings. Possible values are merge_all, merge_replace and replace_all
+  name: APPLY_RULE
+  value: 'merge_all'
+- description: location where yacfg generates the configuration files.
+  name: TUNE_PATH
+  value: '/yacfg_etc'
+- description: Whether to enable artemis metrics plugin
+  displayName: Enable Metrics Plugin
+  name: AMQ_ENABLE_METRICS_PLUGIN
+  value: 'false'
+  required: false
+- description: Journal type to use; aio or nio supported
+  displayName: AMQ Journal Type
+  name: AMQ_JOURNAL_TYPE
+  value: nio
+  required: false


### PR DESCRIPTION
User can use one of the *-with-init.yaml templates to update the
address-settings of the broker. Within the templates an init container
is added on top of the main broker container. The init container's
image (https://github.com/artemiscloud/activemq-artemis-broker-init-image)
has a tool called yacfg (https://github.com/rh-messaging-qe/yacfg) that
generates broker configurations based on user input templates. The generated
configuration(currently only the address-settings) will then be merged
into broker's configuration before launching the broker.

How to use

Step 1. User need to prepare a yaml template(a tuning file in yacfg's term)
and put it into a file.

Here is an example file called as_tune.yaml:

user_address_settings:
  - match: '#'
    address_full_policy: PAGE
    dead_letter_address: DLQ
    expiry_address: ExpiryQueue
    max_size_bytes: -1
  - match: 'jms'
    dead_letter_address: JMSDLQ

Step 2. Pick one from the *-with-init.yaml templates
for example templates/activemq-artemis-persistence-clustered-ssl-with-init.yaml
and create your deployment in to cluster (using openshift)

oc process -f templates/activemq-artemis-persistence-clustered-ssl-with-init.yaml \
-p APPLICATION_NAME=application0 -p AMQ_USER=admin -p AMQ_PASSWORD=admin \
-p AMQ_NAME=amq0 -p AMQ_KEYSTORE="broker.ks" -p AMQ_KEYSTORE_PASSWORD="password" \
-p AMQ_TRUSTSTORE="broker.ts" -p AMQ_TRUSTSTORE_PASSWORD="password" -p AMQ_REPLICAS="2" \
-p AMQ_CLUSTERED="true" -p AMQ_EXTRA_ARGS=--no-autotune \
-p ADDRESS_SETTINGS_CONFIG="$(cat as_tune.yaml)" | oc create -f -

During deployment the custom address-settings in as_tune.yaml will be merged
into broker's configuration in every running pod.

Merge options:
There is a parameter called APPLY_RULE that controls how custom
address-settings is merged into existing ones in broker.xml.
It has three possible values:

'merge_all' - For a matching address or set of addresses, merge the specified address
 settings with any address settings that also match those addresses in the existing broker
 configuration. However, do not replace any values that already exist in the default broker
 configuration. This is default value.

'merge_replace' - For a matching address or set of addresses, merge the specified address
 settings with those in the default broker configuration. Replace any values that already
 exist in the default broker configuration with those specified in your custom settings.

'replace_all' - For a matching address or set of addresses, remove all address settings
 in the default broker configuration. Replace the removed address settings with only
 those specified in your custom settings.

For example if you want the above deployment with "replace_all" rule, pass in the parameter
as follows:

oc process -f templates/activemq-artemis-persistence-clustered-ssl-with-init.yaml \
...
-p ADDRESS_SETTINGS_CONFIG="$(cat as_tune.yaml)" -p APPLY_RULE=replace_all | oc create -f -

Thanks for submitting your Pull Request!

Please make sure your PR meets the following requirements:

- [ ] Pull Request title is properly formatted: `[CLOUD-XYA] Subject`
- [ ] Pull Request contains link to the JIRA issue
- [ ] Pull Request contains description of the issue
- [ ] Pull Request does not include fixes for issues other than the main ticket
- [ ] Attached commits represent units of work and are properly formatted
- [ ] You have read and agreed to the Developer Certificate of Origin (DCO) (see `CONTRIBUTING.md`)
- [ ] Every commit contains `Signed-off-by: Your Name <yourname@example.com>` - use `git commit -s`