### PR TITLE
Update to support custom init (ENTMQBR-4369)

### DIFF
--- a/image.yaml
+++ b/image.yaml
@@ -3,7 +3,7 @@ schema_version: 1
 name: "artemiscloud/activemq-artemis-broker-kubernetes"
 description: "ActiveMQ Artemis broker kubernetes container image"
 version: "0.2.0"
-from: "quay.io/artemiscloud/activemq-artemis-broker:0.1.0"
+from: "quay.io/artemiscloud/activemq-artemis-broker:0.1.1"
 labels:
     - name: "io.k8s.description"
       value: "A reliable messaging platform that supports standard messaging paradigms for a real-time enterprise."

--- a/modules/activemq-artemis-launch/added/launch.sh
+++ b/modules/activemq-artemis-launch/added/launch.sh
@@ -593,12 +593,12 @@ function configure() {
     fi
 
 
-    echo "Creating Broker with args $PRINT_ARGS"
+    echo "Creating Broker with args $PRINT_ARGS at ${instanceDir}"
     $AMQ_HOME/bin/artemis create ${instanceDir} $AMQ_ARGS --java-options "$JAVA_OPTS"
 
     echo "Checking yacfg file under dir: $TUNE_PATH"
 
-    if [ -f "${TUNE_PATH}/broker.xml" ]; then
+    if [[ -f "${TUNE_PATH}/broker.xml" ]]; then
         echo "yacfg broker.xml exists."
         updateAddressSettings "${TUNE_PATH}/broker.xml" "${instanceDir}/etc/broker.xml"
     fi
@@ -629,6 +629,7 @@ function configure() {
 
     $AMQ_HOME/bin/configure_s2i_files.sh ${instanceDir}
     $AMQ_HOME/bin/configure_custom_config.sh ${instanceDir}
+
   fi
 }
 
@@ -637,15 +638,48 @@ function removeWhiteSpace() {
 }
 
 function runServer() {
+  echo "Running server env: home: ${HOME} AMQ_HOME ${AMQ_HOME} CONFIG_BROKER ${CONFIG_BROKER} RUN_BROKER ${RUN_BROKER}"
 
-  echo "Configuring Broker"
   instanceDir="${HOME}/${AMQ_NAME}"
 
-  configure $instanceDir
+  if [ -z ${CONFIG_BROKER+x} ]; then
+    echo "NO CONFIG_BROKER defined"
+    CONFIG_BROKER=true
+  fi
+  if [ -z ${RUN_BROKER+x} ]; then
+    echo "NO RUN_BROKER defined"
+    RUN_BROKER=true
+  fi
 
-  if [ "$1" != "nostart" ]; then
-    echo "Running Broker"
-    exec ${instanceDir}/bin/artemis run
+  if [ "${CONFIG_BROKER}" = "true" ]; then
+    echo "Configuring Broker at ${CONFIG_INSTANCE_DIR}"
+    echo "config Using instanceDir: $instanceDir"
+    configure $instanceDir
+
+    if [ -z "${CONFIG_INSTANCE_DIR+x}" ]; then
+      echo "No CONFIG_INSTANCE_DIR defined"
+    else
+      echo "user defined CONFIG_INSTANCE_DIR, copying"
+      cp -r $instanceDir "${CONFIG_INSTANCE_DIR}"
+      ls ${CONFIG_INSTANCE_DIR}
+    fi
+  fi
+
+  if [ "${RUN_BROKER}" == "true" ]; then
+    if [ "${CONFIG_BROKER}" != "true" ]; then
+      if [ -z "${CONFIG_INSTANCE_DIR+x}" ]; then
+        echo "No custom configuration supplied"
+      else
+        echo "Using custom configuration. Copy from ${CONFIG_INSTANCE_DIR} to ${instanceDir}"
+        rm -rf ${instanceDir}
+        ls ${CONFIG_INSTANCE_DIR}/*
+        cp -r ${CONFIG_INSTANCE_DIR}/* ${HOME}
+      fi
+    fi
+    if [ "$1" != "nostart" ]; then
+      echo "Running Broker in ${instanceDir}"
+      exec ${instanceDir}/bin/artemis run
+    fi
   fi
 }
 

--- a/modules/activemq-artemis-launch/install.sh
+++ b/modules/activemq-artemis-launch/install.sh
@@ -19,7 +19,7 @@ cp -p ${SOURCES_DIR}/openshift-ping-common-$VERSION.jar \
   ${DEST}/lib
 
 cp -p $ADDED_DIR/jgroups-ping.xml \
-  ${DEST}/conf/ 
+  ${DEST}/conf/
 
 cp $ADDED_DIR/launch.sh ${ADDED_DIR}/readinessProbe.sh ${ADDED_DIR}/drain.sh $AMQ_HOME/bin
 chmod 0755 $AMQ_HOME/bin/launch.sh


### PR DESCRIPTION
Added some flags so that the launch script can be
controlled by the flags to perform either configure
or run the broker, or both (default when the flags
are not set)

Thanks for submitting your Pull Request!

Please make sure your PR meets the following requirements:

- [ ] Pull Request title is properly formatted: `[CLOUD-XYA] Subject`
- [ ] Pull Request contains link to the JIRA issue
- [ ] Pull Request contains description of the issue
- [ ] Pull Request does not include fixes for issues other than the main ticket
- [ ] Attached commits represent units of work and are properly formatted
- [ ] You have read and agreed to the Developer Certificate of Origin (DCO) (see `CONTRIBUTING.md`)
- [ ] Every commit contains `Signed-off-by: Your Name <yourname@example.com>` - use `git commit -s`