### PR TITLE
ENTMQBR-5376 AMQ Broker Openshift image 7.9 (CR1): errors in drainer log

### DIFF
--- a/image.yaml
+++ b/image.yaml
@@ -119,6 +119,7 @@ ports:
 packages:
     install:
         - apr
+        - procps-ng
 
 modules:
       repositories:


### PR DESCRIPTION
Issue #24 The command 'ps' is not installed which is used in drain.sh

Thanks for submitting your Pull Request!

Please make sure your PR meets the following requirements:

- [ ] Pull Request title is properly formatted: `[CLOUD-XYA] Subject`
- [ ] Pull Request contains link to the JIRA issue
- [ ] Pull Request contains description of the issue
- [ ] Pull Request does not include fixes for issues other than the main ticket
- [ ] Attached commits represent units of work and are properly formatted
- [ ] You have read and agreed to the Developer Certificate of Origin (DCO) (see `CONTRIBUTING.md`)
- [ ] Every commit contains `Signed-off-by: Your Name <yourname@example.com>` - use `git commit -s`