### PR TITLE
[#49] (second commit) Fix scaledown issue with OCP

### DIFF
--- a/image.yaml
+++ b/image.yaml
@@ -127,6 +127,7 @@ packages:
   install:
     - apr
     - procps-ng
+    - bind-utils
 
 modules:
   repositories:


### PR DESCRIPTION
drain.sh cannot rely on /etc/resolv.conf
to resolve the cluster domain name as it has different contents in Kubernetes and OCP. Instead it uses
nslookup tool to find out the target nodes full
hostname.

Thanks for submitting your Pull Request!

Please make sure your PR meets the following requirements:

- [ ] Pull Request title is properly formatted: `[CLOUD-XYA] Subject`
- [ ] Pull Request contains link to the JIRA issue
- [ ] Pull Request contains description of the issue
- [ ] Pull Request does not include fixes for issues other than the main ticket
- [ ] Attached commits represent units of work and are properly formatted
- [ ] You have read and agreed to the Developer Certificate of Origin (DCO) (see `CONTRIBUTING.md`)
- [ ] Every commit contains `Signed-off-by: Your Name <yourname@example.com>` - use `git commit -s`