### PR TITLE
[#84] Remove additivity = false from audit logging

### DIFF
--- a/modules/activemq-artemis-launch/added/log4j2.properties
+++ b/modules/activemq-artemis-launch/added/log4j2.properties
@@ -41,15 +41,12 @@ logger.critical_analyzer.level=INFO
 # Audit loggers: to enable change levels from OFF to INFO
 logger.audit_base.name = org.apache.activemq.audit.base
 logger.audit_base.level = OFF
-logger.audit_base.additivity = false
 
 logger.audit_resource.name = org.apache.activemq.audit.resource
 logger.audit_resource.level = OFF
-logger.audit_resource.additivity = false
 
 logger.audit_message.name = org.apache.activemq.audit.message
 logger.audit_message.level = OFF
-logger.audit_message.additivity = false
 
 # Jetty logger levels
 logger.jetty.name=org.eclipse.jetty


### PR DESCRIPTION
Remove of  additivity = false as it will prevent the logging to root appender (console)
