### PR TITLE
[#86] Fix apt-get in github workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,7 @@ jobs:
         run: >
           mkdir -p $HOME/.local/bin &&
           echo "$HOME/.local/bin" >> $GITHUB_PATH &&
+          sudo apt-get update &&
           sudo apt-get install gcc libkrb5-dev &&
           sudo pip install docker==5.0.3 docker-squash cekit odcs[client] packaging==21.3 behave lxml &&
           wget -O source-to-image.tar.gz $S2I_RELEASE_URL &&

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,6 +22,7 @@ jobs:
     steps:
       - name: Install prerequisites
         run: >
+          sudo apt-get update &&
           sudo apt-get install gcc libkrb5-dev pass &&
           sudo pip install docker==5.0.3 docker-squash cekit odcs[client] packaging==21.3
       - name: Checkout the repo


### PR DESCRIPTION
apt-get install may fail if it is used directly without update the mirror list with apt-get update

closes #86 