### PR TITLE
[#92] Upgrade artemiscloud/cct_module repo to 0.38.0-artemiscloud-3

### DIFF
--- a/image.yaml
+++ b/image.yaml
@@ -136,7 +136,7 @@ modules:
     - name: cct_module
       git:
         url: https://github.com/artemiscloud/cct_module.git
-        ref: 0.38.0-artemiscloud-2
+        ref: 0.38.0-artemiscloud-3
   install:
     - name: os-amq-s2i
     - name: openshift-passwd


### PR DESCRIPTION
The tag 0.38.0-artemiscloud-3 points to jolokia-jvm 1.7.2