### PR TITLE
[#112] Remove python dependency

### DIFF
--- a/image.yaml
+++ b/image.yaml
@@ -128,6 +128,8 @@ packages:
     - apr
     - procps-ng
     - bind-utils
+    - jq
+    - xmlstarlet
 
 modules:
   repositories:


### PR DESCRIPTION
Python code is only used in readiness probe and drain scripts and it can be replaced by bash commands.
Removing the python dependency improves the container image security reducing the surface attack.