### PR TITLE
[#139] Set GID 0 for Kubernetes volumes

### DIFF
--- a/image.yaml
+++ b/image.yaml
@@ -168,7 +168,9 @@ artifacts:
       target: "prometheus.jar"
 
 run:
-  user: 185
+  # The user is in the group 0 to have access to the volumes mounted
+  # by Kubernetes that are typically owned by UID 0 (root) and GID 0 (root).
+  user: "185:0"
   cmd:
     - "/opt/amq/bin/launch.sh"
     - "start"


### PR DESCRIPTION
Setting GID 0 (root group) allows containers running on Kubernetes to access files in mounted volumes that are typically owned by UID 0 (root) and GID 0 (root).